### PR TITLE
Reuse map keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ hs_err_pid*
 out/
 BS12_MAPMERGE.iml
 *.iml
+
+
+/target


### PR DESCRIPTION
JMerge will use old unused keys instead of generating new one.
Fixes #3 

I know that currently Bay uses mapmerge2 on python, but still it could be helpful for repos which are prefers more traditional approach.

cc @atlantiscze 